### PR TITLE
Populate method docstrings if class is provided

### DIFF
--- a/forwardable/__init__.py
+++ b/forwardable/__init__.py
@@ -31,7 +31,7 @@ class NotCalledInModuleScope(Exception): pass
 class NotCalledInClassScope(Exception): pass
 class WrongDecoratorSyntax(Exception): pass
 
-def def_delegator(wrapped, attr_name, _call_stack_depth=1):
+def def_delegator(wrapped, attr_name, _call_stack_depth=1, obj_class=None):
     """
     Define a property ``attr_name`` in the current class scope which
     forwards accessing of ``self.<attr_name>`` to property
@@ -55,11 +55,13 @@ def def_delegator(wrapped, attr_name, _call_stack_depth=1):
     def deleter(self):
         return delattr(get_wrapped_obj(self), attr_name)
 
+    doc = obj_class.__dict__[attr_name].__doc__ if obj_class else None
+
     scope = frame.f_locals
-    scope[attr_name] = property(getter, setter, deleter)
+    scope[attr_name] = property(getter, setter, deleter, doc)
 
 
-def def_delegators(wrapped, attrs):
+def def_delegators(wrapped, attrs, obj_class=None):
     """
     Define multiple delegations for a single delegatee. Roughly equivalent
     to def_delegator() in a for-loop.
@@ -76,7 +78,7 @@ def def_delegators(wrapped, attrs):
     """
     attrs = split_attrs(attrs) if isinstance(attrs, basestring) else attrs
     for a in attrs:
-        def_delegator(wrapped, a, _call_stack_depth=2)
+        def_delegator(wrapped, a, _call_stack_depth=2, obj_class=obj_class)
 
 
 CLS_SCOPE_KEYS = ("__module__",)

--- a/forwardable/test/test_forwardable.py
+++ b/forwardable/test/test_forwardable.py
@@ -12,6 +12,13 @@ class Foo(object):
     def_delegators('dct', ['values', 'items'])
     dct = {'key': 42}
 
+@forwardable()
+class DocFoo(object):
+    assert "def_delegator" not in locals()
+    def_delegator('dct', 'keys', obj_class=dict)
+    def_delegators('dct', ['values', 'items'], obj_class=dict)
+    dct = {'key': 42}
+
 
 assert "def_delegator" not in locals()
 
@@ -23,7 +30,24 @@ class TestForwardable(TestCase):
         self.assertEqual(list(foo.values()), [42])
         self.assertEqual(list(foo.items()), [('key', 42)])
 
-        self.assertFalse(hasattr(foo, "get")) 
+        self.assertFalse(hasattr(foo, "get"))
+
+    def test_inject_with_doc(self):
+        self.assertTrue(Foo.keys.__doc__ is None)
+
+        foo = DocFoo()
+
+        # Test normal functionality
+        self.assertEqual(list(foo.keys()), ['key'])
+        self.assertEqual(list(foo.values()), [42])
+        self.assertEqual(list(foo.items()), [('key', 42)])
+
+        self.assertFalse(hasattr(foo, "get"))
+
+        # Check that docstrings of class is populated
+        self.assertTrue(DocFoo.keys.__doc__ is not None)
+        self.assertTrue(DocFoo.values.__doc__ is not None)
+        self.assertTrue(DocFoo.items.__doc__ is not None)
 
     def test_in_non_module_scope(self):
         with self.assertRaises(NotCalledInModuleScope):


### PR DESCRIPTION
This adds docstrings to the "forwardable" class (objects seem to get the docstrings already)

Add an optional parameter to inform the def_delegator of the delegated
class allowing it to populate the docstrings of the new properties.

This is totally optional but is useful for getting documented classes. I still seem to have some issues with getting the new members to show up in sphinx doc but when using `help(MyClass)` it shows just fine.

I'm not sure if this is the best way to handle it and feedback is very welcome.